### PR TITLE
form updated to get new field name

### DIFF
--- a/app/views/shared/_add_artifact.html.erb
+++ b/app/views/shared/_add_artifact.html.erb
@@ -12,7 +12,7 @@
     <%= f.input :price, class: 'form-control' %>
   </div>
   <div class="col-sm-6">
-    <%= f.input :discount, class: 'form-control', :as => "select" %>
+    <%= f.input :percent_discount, class: 'form-control' %>
   </div>
 </div>
 <div class="form-input ">


### PR DESCRIPTION
form bug fixed (discount) with proper filed name `percent_discount`

<img width="425" alt="skarmavbild 2018-11-13 kl 06 20 30" src="https://user-images.githubusercontent.com/30208247/48392632-7a2a0c80-e70c-11e8-9346-000521ad869a.png">
